### PR TITLE
Add support for ATTiny84

### DIFF
--- a/Adafruit_Trellis.cpp
+++ b/Adafruit_Trellis.cpp
@@ -15,13 +15,6 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#ifdef __AVR_ATtiny85__
-  #include <TinyWireM.h>
-  #define Wire TinyWireM
-#else
-  #include <Wire.h>
-#endif
-
 #include "Adafruit_Trellis.h"
 
 #define HT16K33_BLINK_CMD       0x80

--- a/Adafruit_Trellis.h
+++ b/Adafruit_Trellis.h
@@ -29,8 +29,9 @@
  #include "WProgram.h"
 #endif
 
-#ifdef __AVR_ATtiny85__
+#if defined __AVR_ATtiny85__ || defined __AVR_ATtiny84__
   #include <TinyWireM.h>
+  #define Wire TinyWireM
 #else
   #include <Wire.h>
 #endif

--- a/examples/TrellisGameofLife/TrellisGameofLife.ino
+++ b/examples/TrellisGameofLife/TrellisGameofLife.ino
@@ -15,7 +15,6 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Wire.h>
 #include "Adafruit_Trellis.h"
 
 Adafruit_Trellis matrix0 = Adafruit_Trellis();

--- a/examples/TrellisLightsOut/TrellisLightsOut.ino
+++ b/examples/TrellisLightsOut/TrellisLightsOut.ino
@@ -17,7 +17,6 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Wire.h>
 #include "Adafruit_Trellis.h"
 
 Adafruit_Trellis matrix0 = Adafruit_Trellis();

--- a/examples/TrellisTest/TrellisTest.ino
+++ b/examples/TrellisTest/TrellisTest.ino
@@ -15,7 +15,6 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Wire.h>
 #include "Adafruit_Trellis.h"
 
 /*************************************************** 


### PR DESCRIPTION
Modified Adafruit_Trellis.* to handle __AVR_ATtiny84__ define, and moved
'Wire -> TinyWireM' redefine into the header. Also updated the examples to
remove the explicit '#include <Wire.h>' which clash with the redefine.

Tested: TrellisTest compiles and runs on ATTiny84, TrellisLightsOut and
TrellisGameofLife compile with 'low memory' warning.